### PR TITLE
Feat  separate message from stack trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The test object in the report includes the following [CTRF properties](https://c
 | `rawStatus` | String  | Optional | The original jest status of the test before mapping to CTRF status.                 |
 | `type`      | String  | Optional | The type of test (e.g., `unit`, `component`).                                       |
 | `filepath`  | String  | Optional | The file path where the test is located in the project.                             |
-| `retries`     | Number  | Optional | The number of retries attempted for the test.                                       |
+| `retries`   | Number  | Optional | The number of retries attempted for the test.                                       |
 | `flaky`     | Boolean | Optional | Indicates whether the test result is flaky.                                         |
 
 ## Support Us

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "jest-ctrf-json-report",
-  "version": "0.0.1",
+  "name": "jest-ctrf-json-reporter",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "jest-ctrf-json-report",
-      "version": "0.0.1",
-      "license": "ISC",
+      "name": "jest-ctrf-json-reporter",
+      "version": "0.0.6",
+      "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.6",
         "@types/node": "^20.8.7",

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -152,7 +152,7 @@ class GenerateCtrfReport implements Reporter {
     const messageStackTracePattern = /^\s{4}at/mu
     // eslint-disable-next-line no-control-regex
     const colorCodesPattern = /\x1b\[\d+m/gmu
-  
+
     if (
       testResult.status === 'failed' &&
       testResult.failureMessages !== undefined
@@ -161,12 +161,20 @@ class GenerateCtrfReport implements Reporter {
       if (testResult.failureMessages !== undefined) {
         const joinedMessages = testResult.failureMessages.join('\n')
         const match = joinedMessages.match(messageStackTracePattern)
-        failureDetails.message = joinedMessages.slice(0, match?.index).replace(colorCodesPattern, '')
-        failureDetails.trace = joinedMessages.slice(match?.index).split('\n').map((line) => {return line.trim() }).join("\n")
+        failureDetails.message = joinedMessages
+          .slice(0, match?.index)
+          .replace(colorCodesPattern, '')
+        failureDetails.trace = joinedMessages
+          .slice(match?.index)
+          .split('\n')
+          .map((line) => {
+            return line.trim()
+          })
+          .join('\n')
       }
-      
+
       if (testResult.failureDetails !== undefined) {
-          failureDetails.trace = testResult.failureMessages.join('\r\n')
+        failureDetails.trace = testResult.failureMessages.join('\r\n')
       }
       return failureDetails
     }

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -154,10 +154,18 @@ class GenerateCtrfReport implements Reporter {
     ) {
       const failureDetails: Partial<CtrfTest> = {}
       if (testResult.failureMessages !== undefined) {
-        failureDetails.message = testResult.failureMessages.join('\r\n')
-      }
-      if (testResult.failureDetails !== undefined) {
-        failureDetails.trace = testResult.failureMessages.join('\r\n')
+        const regEx = /^\s+at (.*?):(\d+):(\d+)\)?$/mu
+        const colorCodes = /\x1b\[\d+m/gmu
+        const joined = testResult.failureMessages.join('\n')
+        const tested = joined.match(regEx)
+        if (tested !== null)
+          failureDetails.message = joined.slice(0, tested?.index)
+        else failureDetails.message = testResult.failureMessages.join('\r\n')
+        if (testResult.failureDetails !== undefined) {
+          if (tested !== null)
+            failureDetails.trace = joined.slice(tested.index, joined.length)
+          else failureDetails.trace = testResult.failureMessages.join('\r\n')
+        }
       }
       return failureDetails
     }

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -150,6 +150,7 @@ class GenerateCtrfReport implements Reporter {
 
   extractFailureDetails(testResult: AssertionResult): Partial<CtrfTest> {
     const messageStackTracePattern = /^\s{4}at/mu
+    // eslint-disable-next-line no-control-regex
     const colorCodesPattern = /\x1b\[\d+m/gmu
   
     if (

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -160,10 +160,7 @@ class GenerateCtrfReport implements Reporter {
       if (testResult.failureMessages !== undefined) {
         const joinedMessages = testResult.failureMessages.join('\n')
         const match = joinedMessages.match(messageStackTracePattern)
-        // slice message until stack trace part is found and remove ansi color codes
         failureDetails.message = joinedMessages.slice(0, match?.index).replace(colorCodesPattern, '')
-
-        // slice from begin of stack trace, remove indentation of each line and return the trace as string
         failureDetails.trace = joinedMessages.slice(match?.index).split('\n').map((line) => {return line.trim() }).join("\n")
       }
       

--- a/test/generate-report.test.ts
+++ b/test/generate-report.test.ts
@@ -54,12 +54,6 @@ describe('GenerateCtrfReport', () => {
       expect((reporter as any).filename).toBe('myReport.json')
     })
 
-    it('should fail', () => {
-      ;(reporter as any).setFilename('myReport')
-      const falseVar= false;
-      expect(falseVar).toBe(true)
-    })
-
     it('should keep .json extension if already provided', () => {
       ;(reporter as any).setFilename('myReport.json')
       expect((reporter as any).filename).toBe('myReport.json')
@@ -209,14 +203,14 @@ describe('GenerateDetailedCtrfReport', () => {
     )
   })
 
-  it('should update the ctrfReport message on failed builds', () => {
+  it('should update the ctrfReport message with error description from failureMessages on failed builds', () => {
     const mockTestCaseResult = {
       status: 'failed' as Status,
       fullName: 'Test Case Full Name',
       ancestorTitles: ['parent'],
       duration: 100,
       
-      failureMessages: ["Error"]
+      failureMessages: ['Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m\"b\"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n)'] 
     }
     const mockResult: TestResult = {
       testFilePath: '/path/to/test.ts',
@@ -227,6 +221,28 @@ describe('GenerateDetailedCtrfReport', () => {
 
     const updatedTestResult = reporter['ctrfReport'].results.tests[0]
 
-    expect(updatedTestResult.message).toBe('Error')
+    expect(updatedTestResult.message).toBe('Error: expect(received).toBe(expected) // Object.is equality\n\nExpected: "b"\nReceived: undefined\n')
   })
+
+  it('should update the ctrfReport trace with stack trace from failureMessage on failed builds', () => {
+    const mockTestCaseResult = {
+      status: 'failed' as Status,
+      fullName: 'Test Case Full Name',
+      ancestorTitles: ['parent'],
+      duration: 100,
+      
+      failureMessages: ['Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m\"b\"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n'] 
+    }
+    const mockResult: TestResult = {
+      testFilePath: '/path/to/test.ts',
+      testResults: [mockTestCaseResult],
+    } as TestResult
+
+    ;(reporter as any).updateCtrfTestResultsFromTestResult(mockResult)
+
+    const updatedTestResult = reporter['ctrfReport'].results.tests[0]
+
+    expect(updatedTestResult.trace).toBe('at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\nat Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n')
+  })
+
 })

--- a/test/generate-report.test.ts
+++ b/test/generate-report.test.ts
@@ -187,13 +187,12 @@ describe('GenerateCtrfReport', () => {
   })
 })
 
-
 describe('GenerateDetailedCtrfReport', () => {
   let reporter: GenerateCtrfReport
   beforeEach(() => {
     const mockGlobalConfig: Config.GlobalConfig = {} as Config.GlobalConfig
     const mockreporterOptions: ReporterConfigOptions = {
-      minimal: false
+      minimal: false,
     } as ReporterConfigOptions
     const mockreporterContext: ReporterContext = {} as ReporterContext
     reporter = new GenerateCtrfReport(
@@ -209,8 +208,10 @@ describe('GenerateDetailedCtrfReport', () => {
       fullName: 'Test Case Full Name',
       ancestorTitles: ['parent'],
       duration: 100,
-      
-      failureMessages: ['Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m\"b\"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n)'] 
+
+      failureMessages: [
+        'Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m"b"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n)',
+      ],
     }
     const mockResult: TestResult = {
       testFilePath: '/path/to/test.ts',
@@ -221,7 +222,9 @@ describe('GenerateDetailedCtrfReport', () => {
 
     const updatedTestResult = reporter['ctrfReport'].results.tests[0]
 
-    expect(updatedTestResult.message).toBe('Error: expect(received).toBe(expected) // Object.is equality\n\nExpected: "b"\nReceived: undefined\n')
+    expect(updatedTestResult.message).toBe(
+      'Error: expect(received).toBe(expected) // Object.is equality\n\nExpected: "b"\nReceived: undefined\n'
+    )
   })
 
   it('should update the ctrfReport trace with stack trace from failureMessage on failed builds', () => {
@@ -230,8 +233,10 @@ describe('GenerateDetailedCtrfReport', () => {
       fullName: 'Test Case Full Name',
       ancestorTitles: ['parent'],
       duration: 100,
-      
-      failureMessages: ['Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m\"b\"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n'] 
+
+      failureMessages: [
+        'Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m"b"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n',
+      ],
     }
     const mockResult: TestResult = {
       testFilePath: '/path/to/test.ts',
@@ -242,7 +247,8 @@ describe('GenerateDetailedCtrfReport', () => {
 
     const updatedTestResult = reporter['ctrfReport'].results.tests[0]
 
-    expect(updatedTestResult.trace).toBe('at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\nat Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n')
+    expect(updatedTestResult.trace).toBe(
+      'at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\nat Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n'
+    )
   })
-
 })

--- a/test/generate-report.test.ts
+++ b/test/generate-report.test.ts
@@ -54,6 +54,12 @@ describe('GenerateCtrfReport', () => {
       expect((reporter as any).filename).toBe('myReport.json')
     })
 
+    it('should fail', () => {
+      ;(reporter as any).setFilename('myReport')
+      const falseVar= false;
+      expect(falseVar).toBe(true)
+    })
+
     it('should keep .json extension if already provided', () => {
       ;(reporter as any).setFilename('myReport.json')
       expect((reporter as any).filename).toBe('myReport.json')

--- a/test/generate-report.test.ts
+++ b/test/generate-report.test.ts
@@ -192,3 +192,41 @@ describe('GenerateCtrfReport', () => {
     )
   })
 })
+
+
+describe('GenerateDetailedCtrfReport', () => {
+  let reporter: GenerateCtrfReport
+  beforeEach(() => {
+    const mockGlobalConfig: Config.GlobalConfig = {} as Config.GlobalConfig
+    const mockreporterOptions: ReporterConfigOptions = {
+      minimal: false
+    } as ReporterConfigOptions
+    const mockreporterContext: ReporterContext = {} as ReporterContext
+    reporter = new GenerateCtrfReport(
+      mockGlobalConfig,
+      mockreporterOptions,
+      mockreporterContext
+    )
+  })
+
+  it('should update the ctrfReport message on failed builds', () => {
+    const mockTestCaseResult = {
+      status: 'failed' as Status,
+      fullName: 'Test Case Full Name',
+      ancestorTitles: ['parent'],
+      duration: 100,
+      
+      failureMessages: ["Error"]
+    }
+    const mockResult: TestResult = {
+      testFilePath: '/path/to/test.ts',
+      testResults: [mockTestCaseResult],
+    } as TestResult
+
+    ;(reporter as any).updateCtrfTestResultsFromTestResult(mockResult)
+
+    const updatedTestResult = reporter['ctrfReport'].results.tests[0]
+
+    expect(updatedTestResult.message).toBe('Error')
+  })
+})


### PR DESCRIPTION
The CTRF Test objects has a message and a trace attribute. According to
the documentation, the message should contain a description of the test
result and the trace should contain the stack trace of a failed test.

The reporter receives the assertion description and the stack trace
intermingled and stores them both, redundantly, in the message and trace
attributes.

This change splits the assert description from the stack trace as shown
stores them separately. Everything above the dashed line is stored in
message while lines below are stored in trace.
    
    ```
    Error: expect(received).toStrictEqual(expected) // deep equality
    
    - Expected  - 1
    + Received  + 1
    
    @@ -23,11 +23,11 @@
              "isSelected": true,
            },
          ],
          "damper_setup": "damper_1,damper_2",
          "driver": "driver1",
    -     "id": 0,
    +     "id": 1,
          "isCurrentlyUsedInProfile": true,
          "isIntermediateState": true,
          "isSelectedForAll": false,
          "lap": "LapName1",
          "lap_id": 1,
    -------------------------
        at lap-channel-type-table-data-creation.service.spec.ts:185:26
        at zone-testing-bundle.umd.js:409:30)
        at zone-testing-bundle.umd.js:3830:43)
        at zone.js/bundles/zone-testing-bundle.umd.js:408:56)
    ```
    
This simplifies processing of both values for later tools when eval-
uating the test results.


Note: I'm totally new to TypeScript, got a short introduction from my co-worker today to be able to start this. Hints on style are welcome, therefore.