### PR TITLE
fix: handling of AssertionResult.failureDetails

### DIFF
--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -174,7 +174,7 @@ class GenerateCtrfReport implements Reporter {
         failureDetails.message = joinedMessages
           .slice(0, match?.index)
           .replace(colorCodesPattern, '')
-        
+
         failureDetails.trace = joinedMessages
           .slice(match?.index)
           .split('\n')
@@ -185,7 +185,10 @@ class GenerateCtrfReport implements Reporter {
       }
 
       if (testResult.failureDetails !== undefined) {
-        failureDetails.trace = failureDetails.trace?.concat('\n\n', testResult.failureDetails.join('\n'))
+        failureDetails.trace = failureDetails.trace?.concat(
+          '\n\n',
+          testResult.failureDetails.join('\n')
+        )
       }
       return failureDetails
     }

--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -174,6 +174,7 @@ class GenerateCtrfReport implements Reporter {
         failureDetails.message = joinedMessages
           .slice(0, match?.index)
           .replace(colorCodesPattern, '')
+        
         failureDetails.trace = joinedMessages
           .slice(match?.index)
           .split('\n')
@@ -184,7 +185,7 @@ class GenerateCtrfReport implements Reporter {
       }
 
       if (testResult.failureDetails !== undefined) {
-        failureDetails.trace = testResult.failureMessages.join('\r\n')
+        failureDetails.trace = failureDetails.trace?.concat('\n\n', testResult.failureDetails.join('\n'))
       }
       return failureDetails
     }

--- a/test/generate-report.test.ts
+++ b/test/generate-report.test.ts
@@ -233,7 +233,6 @@ describe('GenerateDetailedCtrfReport', () => {
       fullName: 'Test Case Full Name',
       ancestorTitles: ['parent'],
       duration: 100,
-
       failureMessages: [
         'Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m"b"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n',
       ],
@@ -249,6 +248,31 @@ describe('GenerateDetailedCtrfReport', () => {
 
     expect(updatedTestResult.trace).toBe(
       'at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\nat Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n'
+    )
+  })
+
+  it('should append failureDetails to trace', () => {
+    const mockTestCaseResult = {
+      status: 'failed' as Status,
+      fullName: 'Test Case Full Name',
+      ancestorTitles: ['parent'],
+      failureDetails: ['details'],
+      duration: 100,
+      failureMessages: [
+        'Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22m\u001b[32mexpected\u001b[39m\u001b[2m) // Object.is equality\u001b[22m\n\nExpected: \u001b[32m"b"\u001b[39m\nReceived: \u001b[31mundefined\u001b[39m\n    at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\n    at Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n',
+      ],
+    }
+    const mockResult: TestResult = {
+      testFilePath: '/path/to/test.ts',
+      testResults: [mockTestCaseResult],
+    } as TestResult
+
+    ;(reporter as any).updateCtrfTestResultsFromTestResult(mockResult)
+
+    const updatedTestResult = reporter['ctrfReport'].results.tests[0]
+
+    expect(updatedTestResult.trace).toBe(
+      'at Object.<anonymous> (/jest-ctrf-json-reporter/test/generate-report.test.ts:133:41)\nat Promise.then.completed (/jest-ctrf-json-reporter/node_modules/jest-circus/build/utils.js:298:28)\n\n\ndetails'
     )
   })
 })


### PR DESCRIPTION
Append AssertionResult.failureDetails to CtrfTest.trace when setting .trace and .message attributes from the AssertionResult to prevent overwriting .trace when AssertionResult.failureDetails is set.