### PR TITLE
fix: capture ctrf.extra() metadata from beforeEach/afterEach hooks (#68)

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -240,13 +240,22 @@ export function createCtrfJestEnvironment<T extends typeof JestEnvironment>(
 		/**
 		 * Handle Jest Circus test events
 		 */
-		handleTestEvent = (event: Circus.Event, _state: Circus.State): void => {
+		handleTestEvent = (event: Circus.Event, state: Circus.State): void => {
 			switch (event.name) {
 				case "run_describe_start":
 					this.handleSuiteStart();
 					break;
 				case "run_describe_finish":
 					this.handleSuiteEnd();
+					break;
+				case "hook_start":
+					this.handleHookStart(event.hook, state);
+					break;
+				case "hook_success":
+					this.handleHookEnd(event.hook);
+					break;
+				case "hook_failure":
+					this.handleHookEnd(event.hook);
 					break;
 				case "test_fn_start":
 					this.handleTestStart(event.test);
@@ -269,6 +278,36 @@ export function createCtrfJestEnvironment<T extends typeof JestEnvironment>(
 			}
 		};
 
+		private handleHookStart(hook: Circus.Hook, state: Circus.State): void {
+			if (hook.type !== "beforeEach" && hook.type !== "afterEach") return;
+
+			const currentTest = state.currentlyRunningTest;
+			if (!currentTest) return;
+
+			const testPath = getTestPath(currentTest);
+			const testId = getTestId(testPath);
+
+			if (!this.runContext.tests.has(testId)) {
+				const fullName = `${this.testPath} > ${testId}`;
+				this.runContext.tests.set(testId, {
+					name: currentTest.name,
+					fullName,
+					filePath: this.testPath,
+					startedAt: Date.now(),
+					duration: 0,
+					status: "other",
+					metadata: { extra: {} },
+				});
+			}
+
+			this.runContext.executables.push(testId);
+		}
+
+		private handleHookEnd(hook: Circus.Hook): void {
+			if (hook.type !== "beforeEach" && hook.type !== "afterEach") return;
+			this.runContext.executables.pop();
+		}
+
 		private handleSuiteStart(): void {
 			const scopeId = Math.random().toString(36).substring(2, 15);
 			this.runContext.scopes.push(scopeId);
@@ -283,6 +322,9 @@ export function createCtrfJestEnvironment<T extends typeof JestEnvironment>(
 			const testId = getTestId(testPath);
 			const fullName = `${this.testPath} > ${testId}`;
 
+			// Preserve metadata collected by beforeEach hooks before test_fn_start
+			const existingMetadata = this.runContext.tests.get(testId)?.metadata;
+
 			this.runContext.tests.set(testId, {
 				name: test.name,
 				fullName,
@@ -290,9 +332,7 @@ export function createCtrfJestEnvironment<T extends typeof JestEnvironment>(
 				startedAt: test.startedAt ?? Date.now(),
 				duration: 0,
 				status: "other", // Will be updated
-				metadata: {
-					extra: {},
-				},
+				metadata: existingMetadata ?? { extra: {} },
 			});
 
 			this.runContext.executables.push(testId);

--- a/test/environment.test.ts
+++ b/test/environment.test.ts
@@ -1,0 +1,89 @@
+import { createCtrfJestEnvironment } from "jest-ctrf-json-reporter/environment";
+import {
+	consumeTestMetadata,
+	clearAllMetadata,
+} from "jest-ctrf-json-reporter/storage";
+import type { Circus } from "@jest/types";
+
+class MockBase {
+	global: any = {};
+	async setup(): Promise<void> {}
+	async teardown(): Promise<void> {}
+}
+
+const CtrfEnv = createCtrfJestEnvironment(MockBase as any);
+
+function makeEnv() {
+	return new (CtrfEnv as any)(
+		{ projectConfig: { rootDir: "/", testEnvironmentOptions: {} } },
+		{ testPath: "/example.test.ts" },
+	);
+}
+
+function makeTestEntry(name: string): Circus.TestEntry {
+	const root = { name: "ROOT_DESCRIBE_BLOCK", parent: undefined } as any;
+	return { name, parent: root } as any;
+}
+
+describe("CtrfJestEnvironment hook metadata", () => {
+	beforeEach(() => {
+		clearAllMetadata();
+	});
+
+	it("captures extra() called in beforeEach for the current test", () => {
+		const env = makeEnv();
+		const test = makeTestEntry("should fetch user");
+		const state = { currentlyRunningTest: test } as Circus.State;
+		const hook = { type: "beforeEach" } as Circus.Hook;
+
+		env.handleTestEvent({ name: "hook_start", hook }, state);
+		env.handleRuntimeMessage({ type: "extra", data: { owner: "alice" } });
+		env.handleTestEvent({ name: "hook_success", hook, test }, state);
+
+		env.handleTestEvent({ name: "test_fn_start", test }, state);
+		env.handleTestEvent({ name: "test_fn_success", test }, state);
+		env.handleTestEvent({ name: "run_finish" }, state);
+
+		const metadata = consumeTestMetadata("should fetch user");
+		expect(metadata?.extra).toEqual({ owner: "alice" });
+	});
+
+	it("captures extra() called in afterEach for the current test", () => {
+		const env = makeEnv();
+		const test = makeTestEntry("should update user");
+		const state = { currentlyRunningTest: test } as Circus.State;
+		const hook = { type: "afterEach" } as Circus.Hook;
+
+		env.handleTestEvent({ name: "test_fn_start", test }, state);
+		env.handleTestEvent({ name: "test_fn_success", test }, state);
+
+		env.handleTestEvent({ name: "hook_start", hook }, state);
+		env.handleRuntimeMessage({ type: "extra", data: { result: "ok" } });
+		env.handleTestEvent({ name: "hook_success", hook, test }, state);
+
+		env.handleTestEvent({ name: "run_finish" }, state);
+
+		const metadata = consumeTestMetadata("should update user");
+		expect(metadata?.extra).toEqual({ result: "ok" });
+	});
+
+	it("deep merges extra() from beforeEach and the test body", () => {
+		const env = makeEnv();
+		const test = makeTestEntry("should delete user");
+		const state = { currentlyRunningTest: test } as Circus.State;
+		const hook = { type: "beforeEach" } as Circus.Hook;
+
+		env.handleTestEvent({ name: "hook_start", hook }, state);
+		env.handleRuntimeMessage({ type: "extra", data: { owner: "alice" } });
+		env.handleTestEvent({ name: "hook_success", hook, test }, state);
+
+		env.handleTestEvent({ name: "test_fn_start", test }, state);
+		env.handleRuntimeMessage({ type: "extra", data: { priority: "P1" } });
+		env.handleTestEvent({ name: "test_fn_success", test }, state);
+
+		env.handleTestEvent({ name: "run_finish" }, state);
+
+		const metadata = consumeTestMetadata("should delete user");
+		expect(metadata?.extra).toEqual({ owner: "alice", priority: "P1" });
+	});
+});


### PR DESCRIPTION
## Problem

Fixes #68.

`ctrf.extra()` called from `beforeEach`/`afterEach` was silently dropped.
`handleRuntimeMessage()` → `getCurrentTestId()` returned `undefined` because
the executables stack was only populated on `test_fn_start`, which fires after
all `beforeEach` hooks.

## Solution

Handle `hook_start`, `hook_success`, `hook_failure` in `handleTestEvent`:

- **`hook_start`** (beforeEach/afterEach only): creates test entry if absent,
  pushes test ID onto executables stack so `getCurrentTestId()` works during hook
- **`hook_success`/`hook_failure`**: pop test ID from stack
- **`handleTestStart`**: preserve metadata already collected by `beforeEach`

`beforeAll`/`afterAll` excluded — ambiguous which test to attach to.

## Tests

New `test/environment.test.ts`:
- `extra()` in `beforeEach` captured for the test
- `extra()` in `afterEach` captured for the test  
- Deep merge of `beforeEach` + test body calls